### PR TITLE
Allowed users to set multiple DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These can easily be added when running the stack
 ## Environment Variables
 ```env
 ZONE=Id of the zone to use
-RECORD=Id of the record
+RECORDS=IDs of the record separated with a comma
 TOKEN=API Token
 ```
 ## Get API Token
@@ -26,4 +26,4 @@ https://dash.cloudflare.com/profile/api-tokens
 ## Get Zone and Record
 Zone can be found in the API Section of the Domains' Overview Page
 
-Program will show you all Records if one isnt provided. Set RECORD env to the correct id.
+Program will show you all Records if one isn't provided. Set RECORDS env to the correct ID.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
     restart: unless-stopped
     environment:
       - ZONE=${ZONE}
-      - RECORD=${RECORD}
+      - RECORDS=${RECORD}
       - TOKEN=${TOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
     restart: unless-stopped
     environment:
       - ZONE=${ZONE}
-      - RECORDS=${RECORD}
+      - RECORDS=${RECORDS}
       - TOKEN=${TOKEN}

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,5 +1,10 @@
 import axios from "axios";
 
+interface ErrorTemplate {
+    recordId: string;
+    errorPresent: boolean;
+}
+
 // Get cloudflare dns records
 export async function getDnsRecords(zoneId: string): Promise<{}[]> {
     const options = {
@@ -59,26 +64,42 @@ export async function checkZone(): Promise<Boolean> {
         }
     }
 }
-// Check dns record exists
-export async function checkRecord(): Promise<Boolean> {
-    const options = {
-        method: "GET",
-        url: `https://api.cloudflare.com/client/v4/zones/${process.env.ZONE}/dns_records/${process.env.RECORD}`,
-        headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.TOKEN}`,
-        },
-    };
-    try {
-        const response = await axios.request(options);
-        return response.status.toString().startsWith("2") ? true : false;
-    } catch (error) {
-        if (axios.isAxiosError(error)) {
-            return error.response.status.toString().startsWith("4")
-                ? false
-                : true;
-        } else {
-            console.error("An unexpected error occurred:", error);
+// Check DNS records exist
+export async function checkRecords(records?: Array<string>): Promise<Boolean> {
+    if (!records && !process.env.RECORDS)
+        throw new TypeError("A valid record must be provided");
+    if (!records && process.env.RECORDS)
+        records = [...process.env.RECORDS.split(",")];
+
+    let errors: Array<ErrorTemplate> = [];
+
+    for await (let record of records) {
+        const options = {
+            method: "GET",
+            url: `https://api.cloudflare.com/client/v4/zones/${process.env.ZONE}/dns_records/${record.trim()}`,
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${process.env.TOKEN}`,
+            },
+        };
+        try {
+            const response = await axios.request(options);
+            let error = !response.status.toString().startsWith("2");
+            if (error)
+                errors.push({ errorPresent: true, recordId: record.trim() });
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                if (error.response.status.toString().startsWith("4"))
+                    errors.push({ errorPresent: true, recordId: record.trim() });
+            } else {
+                console.error("An unexpected error occurred:", error);
+            }
         }
     }
+    if (errors.length > 0) {
+        console.log("The following records have failed:")
+        console.log(errors.map(x => x.recordId).join(", "));
+        return false;
+    }
+    return true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import nodeCron from "node-cron";
 import { config } from "dotenv";
 import { main } from "./main.js";
-import { checkToken, checkZone, checkRecord, getDnsRecords } from "./checks.js";
+import { checkToken, checkZone, checkRecords, getDnsRecords } from "./checks.js";
 
 // Interfaces
 export interface DnsRecord {
@@ -48,7 +48,7 @@ async function setup() {
         throw new Error(
             "Zone is not set or is wrong.\nZone can be found in the API Section of the Domains' Overview Page"
         );
-    } else if (!process.env.RECORD || (await checkRecord()) === false) {
+    } else if (!process.env.RECORDS || (await checkRecords()) === false) {
         console.log(
             "Record is not set or is wrong.\nHere are all current records: "
         );


### PR DESCRIPTION
Instead of providing a single RECORD in the environment variables, users can now set multiple RECORDS.

For example:
```
ZONE=<your zone>
TOKEN=<your api token>
RECORDS=<record 1>, <record 2>
```

Also, instead of overwriting data when the IP address is changed, it uses the original data just overwrites the `content` value.