### PR TITLE
Allowed customisable cron schedules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
       - ZONE=${ZONE}
       - RECORDS=${RECORDS}
       - TOKEN=${TOKEN}
+      - CRON_SCHEDULE=${CRON_SCHEDULE}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,6 @@ async function setup() {
         console.log("Please set RECORD env to the correct Record ID");
     } else {
         main();
-        nodeCron.schedule("0 * * * *", main);
+        nodeCron.schedule(process.env.CRON_SCHEDULE || "0 * * * *", main);
     }
 }


### PR DESCRIPTION
Gave users the option to specify a custom schedule for checking their DNS records. If not provided, it still defaults to the hourly schedule.